### PR TITLE
Remove kong.dao.errors for Kong 1.x

### DIFF
--- a/filterable-file-log/schema.lua
+++ b/filterable-file-log/schema.lua
@@ -1,5 +1,5 @@
 -- Modified from https://github.com/Kong/kong/blob/0.14.1/kong/plugins/file-log/schema.lua
-local Errors = require "kong.dao.errors"
+
 local pl_file = require "pl.file"
 local pl_path = require "pl.path"
 
@@ -27,7 +27,7 @@ return {
   self_check = function(schema, config, dao, is_updating)
     for _, field in ipairs({"request_headers", "response_headers"}) do
       if config[field .. "_whitelist"] and config[field .. "_blacklist"] then
-        return false, Errors.schema "You cannot set both a whitelist and a blacklist for " .. field
+        return false
       end
     end
     return true

--- a/filterable-file-log/schema.lua
+++ b/filterable-file-log/schema.lua
@@ -27,7 +27,7 @@ return {
   self_check = function(schema, config, dao, is_updating)
     for _, field in ipairs({"request_headers", "response_headers"}) do
       if config[field .. "_whitelist"] and config[field .. "_blacklist"] then
-        return false
+        return nil, string.format("You cannot set both a whitelist and a blacklist for: %s", field)
       end
     end
     return true


### PR DESCRIPTION
`kong.dao.errors` doesn't seem to play nice with Kong 1.2.1, so I'm just removing it in this branch so that I can try building a Kong that will work. 

I'm basically just stealing what this other plugin team did: https://github.com/stone-payments/kong-plugin-template-transformer/commit/640d20733c25b994dfc7f7d34fe41f05cf9e8927

Also, I don't like that I'm removing the descriptive error message here; it seems like it's useful. But, I don't know offhand how to replace it with something that is Kong 1.x compatible.