### PR TITLE
Log JWT Claims

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
   kong-migrations:
     image: "${KONG_DOCKER_TAG:-kong:1.2.2}"
-    command: kong migrations up
+    command: kong migrations bootstrap
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   kong-migrations:
-    image: "${KONG_DOCKER_TAG:-kong:0.14.1}"
+    image: "${KONG_DOCKER_TAG:-kong:1.2.2}"
     command: kong migrations up
     depends_on:
       db:
@@ -58,7 +58,7 @@ services:
     stdin_open: true
     tty: true
   konga:
-    image: pantsel/konga:legacy
+    image: pantsel/konga
     environment:
       NODE_ENV: production
       TOKEN_SECRET: "${KONGA_SECRET:-secret}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     links:
       - db:db
   kong:
-    image: "${KONG_DOCKER_TAG:-kong:latest}"
+    image: "${KONG_DOCKER_TAG:-kong:1.2.2}"
     depends_on:
       db:
         condition: service_healthy

--- a/filterable-file-log/serializer.lua
+++ b/filterable-file-log/serializer.lua
@@ -2,7 +2,7 @@
 local tablex = require "pl.tablex"
 local list = require "pl.List"
 local stringx = require "pl.stringx"
-local cjson = require "cjson"
+local cjson = require "cjson.safe"
 
 local _M = {}
 
@@ -80,7 +80,11 @@ function get_jwt_claims(headers)
     return nil
   end
 
-  local _, encoded_claims, _ = stringx.split(token, '.')
+  local encoded_claims = stringx.split(token, '.')[2]
+  if not encoded_claims then
+    return nil
+  end
+
   local claims = ngx.decode_base64(encoded_claims)
   return cjson.decode(claims)
 end

--- a/filterable-file-log/serializer.lua
+++ b/filterable-file-log/serializer.lua
@@ -1,6 +1,8 @@
 -- Modified from https://github.com/Kong/kong/blob/0.14.1/kong/plugins/log-serializers/basic.lua
 local tablex = require "pl.tablex"
 local list = require "pl.List"
+local stringx = require "pl.stringx"
+local cjson = require "cjson"
 
 local _M = {}
 
@@ -17,7 +19,9 @@ function _M.serialize(ngx, filters)
 
   local request_uri = ngx.var.request_uri or ""
 
-  req_headers = ngx.req.get_headers()
+  local req_headers = ngx.req.get_headers()
+  local jwt_claims = get_jwt_claims(req_headers)
+
   if filters.request_headers_blacklist then
     req_headers = blacklist_filter(req_headers, filters.request_headers_blacklist)
   elseif filters.request_headers_whitelist then
@@ -60,9 +64,25 @@ function _M.serialize(ngx, filters)
     service = ngx.ctx.service,
     api = ngx.ctx.api,
     consumer = ngx.ctx.authenticated_consumer,
+    jwt_claims = jwt_claims,
     client_ip = ngx.var.remote_addr,
     started_at = ngx.req.start_time() * 1000
   }
+end
+
+function get_jwt_claims(headers)
+  if not headers['authorization'] then
+    return nil
+  end
+
+  token = string.match(headers['authorization'], 'Bearer (.+)')
+  if not token then
+    return nil
+  end
+
+  _, encoded_claims, _ = stringx.split(token, '.')
+  claims = ngx.decode_base64(encoded_claims)
+  return cjson.decode(claims)
 end
 
 function blacklist_filter(t, blacklist)

--- a/filterable-file-log/serializer.lua
+++ b/filterable-file-log/serializer.lua
@@ -75,13 +75,13 @@ function get_jwt_claims(headers)
     return nil
   end
 
-  token = string.match(headers['authorization'], 'Bearer (.+)')
+  local token = string.match(headers['authorization'], 'Bearer (.+)')
   if not token then
     return nil
   end
 
-  _, encoded_claims, _ = stringx.split(token, '.')
-  claims = ngx.decode_base64(encoded_claims)
+  local _, encoded_claims, _ = stringx.split(token, '.')
+  local claims = ngx.decode_base64(encoded_claims)
   return cjson.decode(claims)
 end
 

--- a/filterable-file-log/serializer.lua
+++ b/filterable-file-log/serializer.lua
@@ -75,19 +75,19 @@ function get_jwt_claims(headers)
     return nil
   end
 
-  local token = string.match(headers['authorization'], 'Bearer (.+)')
-  if not token then
-    return nil
-  end
-
-  -- The JWT has three .-delimited parts: header, payload, and signature
-  -- The payload has the claims we're interested in
-  local encoded_claims = stringx.split(token, '.')[2]
+  -- The JWT consists of 2-3 period-delimited, base64 encoded sections (signature is optional):
+  --   header.payload.[signature]
+  -- The claims we're interested in are in the payload, so we capture the second base64 encoded string
+  local encoded_claims = string.match(headers['authorization'], 'Bearer [%w/+]+=?=?%.([%w/+]+=?=?)%.')
   if not encoded_claims then
     return nil
   end
 
   local claims = ngx.decode_base64(encoded_claims)
+  if not claims then
+    return nil
+  end
+
   local parsed_claims, err = cjson.decode(claims)
   if err then
     return nil

--- a/filterable-file-log/serializer.lua
+++ b/filterable-file-log/serializer.lua
@@ -25,14 +25,14 @@ function _M.serialize(ngx, filters)
   if filters.request_headers_blacklist then
     req_headers = blacklist_filter(req_headers, filters.request_headers_blacklist)
   elseif filters.request_headers_whitelist then
-    req_headers = whitelist_filter(req_headers, filters.request_headers_whitelist, "FILTERED")
+    req_headers = whitelist_filter(req_headers, filters.request_headers_whitelist)
   end
 
   resp_headers = ngx.resp.get_headers()
   if filters.response_headers_blacklist then
     resp_headers = blacklist_filter(resp_headers, filters.response_headers_blacklist)
   elseif filters.response_headers_whitelist then
-    resp_headers = whitelist_filter(resp_headers, filters.response_headers_whitelist, "FILTERED")
+    resp_headers = whitelist_filter(resp_headers, filters.response_headers_whitelist)
   end
 
   return {
@@ -114,11 +114,11 @@ function blacklist_filter(t, blacklist)
   end, t)
 end
 
-function whitelist_filter(t, whitelist, replacement)
+function whitelist_filter(t, whitelist)
   whitelist = list(whitelist):map(string.lower)
   return tablex.pairmap(function(k,v)
     if not whitelist:contains(k:lower()) then
-      v = replacement
+      v = "FILTERED"
     end
     return v, k
   end, t)

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,10 @@
 # Filterable File Log
-A fork of the official [Kong file log plugin](https://github.com/Kong/kong/tree/0.14.1/kong/plugins/file-log) that supports filtering fields from the log. Supports Kong 0.14.1
+A fork of the official [Kong file log plugin](https://github.com/Kong/kong/tree/0.14.1/kong/plugins/file-log) that supports filtering fields from the log.
+
+This plugin also logs a subset of claims from a JWT that is presented in an `Authorization: Bearer` header. This behavior is not configurable, and the claims logged are hardcoded.
+
+## Compatibility
+This plugin is forked from Kong 0.14.1, but supports Kong 1.x.
 
 ## Local Development
 


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/4017
https://github.com/department-of-veterans-affairs/vets-contrib/issues/4036

This PR adds some logic to decode an access token and add the claims to the kong logs. At the moment it blindly includes all claims, but we should modify that. I'm looking for feedback about how that should be achieved: should we make that configurable at runtime or just specify it in the code? Or should I only log the `cid` claim and call it a day?

Also welcome any feedback on the code itself – lua is not very familiar to me!