### PR TITLE
Api 3971/alert ip logins

### DIFF
--- a/filterable-file-log/serializer.lua
+++ b/filterable-file-log/serializer.lua
@@ -22,6 +22,8 @@ function _M.serialize(ngx, filters)
   local req_headers = ngx.req.get_headers()
   local jwt_claims = get_jwt_claims(req_headers)
 
+  local error_message = cjson.decode(ngx.var.resp_body).message
+
   if filters.request_headers_blacklist then
     req_headers = blacklist_filter(req_headers, filters.request_headers_blacklist)
   elseif filters.request_headers_whitelist then
@@ -59,6 +61,7 @@ function _M.serialize(ngx, filters)
       proxy = ngx.ctx.KONG_WAITING_TIME or -1,
       request = ngx.var.request_time * 1000
     },
+    err_message = error_message,
     authenticated_entity = authenticated_entity,
     route = ngx.ctx.route,
     service = ngx.ctx.service,


### PR DESCRIPTION
The following changes will allow us to pass the default Kong error message to our logs in preparation for the Client Credentials Grant. Our initial goal is to detect if a consumers key is being used from an IP address that is not associated with their API key.

Alongside changes to the api gateway nginx.template, which will enable the `filterable-file-log` to receive the response body, the changes will look for the default kong error message. If found, the message will be filtered via the `convert_error_message` to simplify our alert system based on the returned value.

Only current concerns are if we have a `message` field within any of our API's, we'll receive an empty string in `err_message`. Not sure if this would cause concern if anyone were to see it, but worth noting.